### PR TITLE
Access token grant params, part 2

### DIFF
--- a/access.go
+++ b/access.go
@@ -53,6 +53,9 @@ func (c *AccessRequest) GetTokenUrl() *url.URL {
 
 	switch c.Type {
 	case PASSWORD:
+		// https://tools.ietf.org/html/rfc6749#section-4.3.2
+		// grant_type, username, password, scope (optional)
+
 		// Avoid double-adding a username parameter if it was specified as a custom parameter and not in AuthorizeData
 		// This ensures callers that previously used CustomParameters to pass username continue to work
 		_, hasCustomUsername := c.CustomParameters["username"]
@@ -66,17 +69,37 @@ func (c *AccessRequest) GetTokenUrl() *url.URL {
 		if len(c.AuthorizeData.Password) > 0 || !hasCustomPassword {
 			uq.Add("password", c.AuthorizeData.Password)
 		}
+
+		// Avoid double-adding a scope parameter if it was specified as a customer parameter
+		// This ensures callers that previously used CustomParameters to pass scope continue to work
+		_, hasCustomScope := c.CustomParameters["scope"]
+		if !hasCustomScope && c.client.config.Scope != "" {
+			uq.Add("scope", c.client.config.Scope)
+		}
+
 	case REFRESH_TOKEN:
+		// https://tools.ietf.org/html/rfc6749#section-6
+		// grant_type, refresh_token, scope (optional, defaults to same as original access token)
 		uq.Add("refresh_token", c.AuthorizeData.Code)
+
 	case AUTHORIZATION_CODE:
+		// https://tools.ietf.org/html/rfc6749#section-4.1.3
+		// grant_type, code, redirect_uri
 		uq.Add("code", c.AuthorizeData.Code)
+		uq.Add("redirect_uri", c.client.config.RedirectUrl)
+
 	case CLIENT_CREDENTIALS:
-		// no auth data added
-	case IMPLICIT:
-		// no auth data added
+		// https://tools.ietf.org/html/rfc6749#section-4.4.2
+		// grant_type, scope
+
+		// Avoid double-adding a scope parameter if it was specified as a customer parameter
+		// This ensures callers that previously used CustomParameters to pass scope continue to work
+		_, hasCustomScope := c.CustomParameters["scope"]
+		if !hasCustomScope && c.client.config.Scope != "" {
+			uq.Add("scope", c.client.config.Scope)
+		}
 	}
 
-	uq.Add("redirect_uri", c.client.config.RedirectUrl)
 	if c.client.config.SendClientSecretInParams {
 		uq.Add("client_id", c.client.config.ClientId)
 		uq.Add("client_secret", c.client.config.ClientSecret)

--- a/access_test.go
+++ b/access_test.go
@@ -9,6 +9,7 @@ func TestGetTokenUrl(t *testing.T) {
 		TokenUrl:     "https://example.com/token",
 		AuthorizeUrl: "https://example.com/authorize",
 		RedirectUrl:  "/",
+		Scope:        "scope1 scope2",
 	}
 
 	testcases := map[string]struct {
@@ -21,7 +22,13 @@ func TestGetTokenUrl(t *testing.T) {
 		"client credentials": {
 			Type: CLIENT_CREDENTIALS,
 			Data: AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
-			URL:  "https://example.com/token?grant_type=client_credentials&redirect_uri=%2F",
+			URL:  "https://example.com/token?grant_type=client_credentials&scope=scope1+scope2",
+		},
+		"client credentials with custom params": {
+			Type:   CLIENT_CREDENTIALS,
+			Data:   AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
+			Params: map[string]string{"scope": "customscope"},
+			URL:    "https://example.com/token?grant_type=client_credentials&scope=customscope",
 		},
 		"code grant": {
 			Type: AUTHORIZATION_CODE,
@@ -31,18 +38,18 @@ func TestGetTokenUrl(t *testing.T) {
 		"refresh grant": {
 			Type: REFRESH_TOKEN,
 			Data: AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
-			URL:  "https://example.com/token?grant_type=refresh_token&redirect_uri=%2F&refresh_token=mycode",
+			URL:  "https://example.com/token?grant_type=refresh_token&refresh_token=mycode",
 		},
 		"password grant": {
 			Type: PASSWORD,
 			Data: AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
-			URL:  "https://example.com/token?grant_type=password&password=mypassword&redirect_uri=%2F&username=myusername",
+			URL:  "https://example.com/token?grant_type=password&password=mypassword&scope=scope1+scope2&username=myusername",
 		},
 		"password grant with custom params": {
 			Type:   PASSWORD,
 			Data:   AuthorizeData{},
-			Params: map[string]string{"username": "customuser", "password": "custompw"},
-			URL:    "https://example.com/token?grant_type=password&password=custompw&redirect_uri=%2F&username=customuser",
+			Params: map[string]string{"username": "customuser", "password": "custompw", "scope": "customscope"},
+			URL:    "https://example.com/token?grant_type=password&password=custompw&scope=customscope&username=customuser",
 		},
 	}
 
@@ -56,7 +63,7 @@ func TestGetTokenUrl(t *testing.T) {
 		req.CustomParameters = tc.Params
 		url := req.GetTokenUrl().String()
 		if url != tc.URL {
-			t.Errorf("%s: Expected %s, got %s", k, tc.URL, url)
+			t.Errorf("%s: Expected\n%s\ngot\n%s", k, tc.URL, url)
 		}
 	}
 }

--- a/util.go
+++ b/util.go
@@ -61,10 +61,6 @@ func downloadData(method string, u *url.URL, auth *BasicAuth, transport http.Rou
 	// must close body
 	defer presp.Body.Close()
 
-	if presp.StatusCode != 200 {
-		return errors.New(fmt.Sprintf("Invalid status code (%d): %s", presp.StatusCode, presp.Status))
-	}
-
 	// decode JSON and detect OAuth error
 	jdec := json.NewDecoder(presp.Body)
 	if err = jdec.Decode(&output); err == nil {
@@ -73,5 +69,11 @@ func downloadData(method string, u *url.URL, auth *BasicAuth, transport http.Rou
 				fmt.Sprintf("%v", output["error_uri"]), fmt.Sprintf("%v", output["state"]))
 		}
 	}
+
+	// If no OAuth error was detected, make sure we don't return success in an error case
+	if err == nil && presp.StatusCode != 200 {
+		return errors.New(fmt.Sprintf("Invalid status code (%d): %s", presp.StatusCode, presp.Status))
+	}
+
 	return err
 }


### PR DESCRIPTION
Follow-up to make the advanced grant token requests follow the spec:

1. Only send the redirect_uri param to grant_type=authorization_code requests

2. Add a scope param to client_credentials and password requests (if defined on the client and not already defined as a custom parameter)

3. Attempt to parse error data from non-200 responses, per https://tools.ietf.org/html/rfc6749#section-5.2 while still returning a generic error in non-200 cases that don't parse to errors